### PR TITLE
Correct curl link

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ Then `prettyping` is the tool for you!
 ## Quick install and run
 
 ```
-curl -O https://github.com/denilsonsa/prettyping/raw/master/prettyping
+curl -O https://raw.githubusercontent.com/denilsonsa/prettyping/master/prettyping
 chmod +x prettyping
 ./prettyping whatever.host.you.want.to.ping
 ```


### PR DESCRIPTION
Curling the existing URL downloaded the 302 redirection:

```
prettyping: line 1: syntax error near unexpected token `<'
prettyping: line 1: `<html><body>You are being <a href="https://raw.githubusercontent.com/denilsonsa/prettyping/master/prettyping">redirected</a>.</body></html>
```

The correct link to curl is https://raw.githubusercontent.com/denilsonsa/prettyping/master/prettyping