### PR TITLE
Fix the download link

### DIFF
--- a/index.md
+++ b/index.md
@@ -12,7 +12,7 @@ Then `prettyping` is the tool for you!
 ## Quick install and run
 
 ```
-curl -O https://github.com/denilsonsa/prettyping/raw/master/prettyping
+curl -O https://raw.githubusercontent.com/denilsonsa/prettyping/master/prettyping
 chmod +x prettyping
 ./prettyping whatever.host.you.want.to.ping
 ```


### PR DESCRIPTION
Change the download link to be the raw script rather than a redirect page

Fixes this problem:

    ~ curl -O https://github.com/denilsonsa/prettyping/raw/master/prettyping
    ~ chmod +x prettyping
    ~ ./prettyping
    ./prettyping: line 1: syntax error near unexpected token `<'
    ./prettyping: line 1: `<html><body>You are being <a href="https://raw.githubusercontent.com/denilsonsa/prettyping/master/prettyping">redirected</a>.</body></html>'