### PR TITLE
Add support for IPv6 on OS X/BSD

### DIFF
--- a/prettyping
+++ b/prettyping
@@ -753,9 +753,11 @@ BEGIN {
 ############################################################
 # Main loop
 {
-	if ( $0 ~ /^[0-9]+ bytes from .*: icmp_[rs]eq=[0-9]+ ttl=[0-9]+ time=[0-9.]+ *ms/ ) {
+	if ( $0 ~ /^[0-9]+ bytes from .*[:,] icmp_[rs]eq=[0-9]+ (ttl|hlim)=[0-9]+ time=[0-9.]+ *ms/ ) {
 		# Sample line from ping:
 		# 64 bytes from 8.8.8.8: icmp_seq=1 ttl=49 time=184 ms
+		# 64 bytes from 2a00:1450:400e:802::200e: icmp_seq=7 ttl=58 time=0.611 ms
+		# 16 bytes from 2a00:1450:400f:804::200e, icmp_seq=0 hlim=49 time=32.272 ms
 		if ( other_line_times >= 2 ) {
 			other_line_finished_repeating()
 		}


### PR DESCRIPTION
Though prettyping works out of the box with v6 on Linux the BSD `ping6` utility has slightly different output.

In ICMPv6 what we know as the TTL in IPv4 is known as the hop limit, or `hlim` in the output. It also uses a comma after the IP instead of a colon as that can get a bit confusing with IPv6 addresses.