### PR TITLE
ping6 has been merged in iputils. param is -6

### DIFF
--- a/prettyping
+++ b/prettyping
@@ -149,7 +149,6 @@ parse_arguments() {
 
 			-awkbin  | --awkbin  ) AWK_BIN="$2"  ; shift ;;
 			-pingbin | --pingbin ) PING_BIN="$2" ; shift ;;
-			-6 ) PING_BIN="ping6" ;;
 
 			#TODO: Check if these parameters are numbers.
 			-last    | --last    ) LAST_N="$2"           ; shift ;;


### PR DESCRIPTION
ping6 has been merged in iputils. The parameter is -6, same as prettyping so it is already handled by the line 160-161
			* )
				PING_PARAMS+=("$1")