### PR TITLE
Handle "No route to host" message on macOS

### DIFF
--- a/prettyping
+++ b/prettyping
@@ -837,6 +837,8 @@ BEGIN {
 		# Do nothing on blank lines.
 	} else if ( $0 == "error shutting down ssl" ) {
 		# Common error message when using httping, ignore it.
+	} else if ( $0 == "ping: sendto: No route to host" ) {
+		# Mac OS X will print a separate timeout line still, so ignore this message
 	} else if ( $0 ~ /^Request timeout for icmp_seq [0-9]+/ ) {
 		# Reply timeout is printed on Mac OS X.
 


### PR DESCRIPTION
On macOS, if your network connection goes down, the prettyping output will be trashed with lots of `ping: sendto: No route to host` lines.

We should just ignore these, because we'll still get the necessary `Request timeout for icmp_seq ...` line soon after.

Closes #24. Closes #25 which also tries to solve this problem but double counts lost packets.