### PR TITLE
Improve support for embedded systems like OpenWrt

### DIFF
--- a/prettyping
+++ b/prettyping
@@ -776,7 +776,7 @@ BEGIN {
 ############################################################
 # Main loop
 {
-	if ( $0 ~ /^[0-9]+ bytes from .*[:,] icmp_[rs]eq=[0-9]+ (ttl|hlim)=[0-9]+ time=[0-9.]+ *ms/ ) {
+	if ( $0 ~ /^[0-9]+ bytes from .*[:,] (icmp_)?[rs]eq=[0-9]+ (ttl|hlim)=[0-9]+ time=[0-9.]+ *ms/ ) {
 		# Sample line from ping:
 		# 64 bytes from 8.8.8.8: icmp_seq=1 ttl=49 time=184 ms
 		if ( other_line_times >= 2 ) {


### PR DESCRIPTION
OpenWrt (and perhaps other embedded systems):
1. Doesn't have `stty` or `tput` commands to discover the terminal size.
2. Uses Busybox ping by default, which prints slightly differently.

This PR fixes both, by: not complaining if tput fails, falling back to bash itself to discover the terminal size, and supporting Busybox ping's output format.